### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = ""

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Random GUID or API Generator
 
 ### Interactive Repl.it
 
-https://repl.it/@AmieDD/Random-generate-GUID
+[![Run on Repl.it](https://repl.it/badge/github/AmieDD/RandomGUIDGenerator)](https://repl.it/github/AmieDD/RandomGUIDGenerator)
 
 ```javascript
 /* Create random GUID generator for API 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AmieDD/RandomGUIDGenerator).